### PR TITLE
Add donor twitter handle meta field

### DIFF
--- a/src/wp-conference-schedule.php
+++ b/src/wp-conference-schedule.php
@@ -1455,6 +1455,15 @@ function wpcsp_donor_metabox() {
 			'type' => 'text',
 		)
 	);
+
+	// Donor Twitter/X.
+	$cmb->add_field(
+		array(
+			'name' => __( 'Twitter/X Handle (Must include @ symbol)', 'wpa-conference' ),
+			'id'   => 'wpcsp_donor_twitter',
+			'type' => 'text',
+		)
+	);	
 }
 
 

--- a/src/wp-conference-schedule.php
+++ b/src/wp-conference-schedule.php
@@ -1463,9 +1463,8 @@ function wpcsp_donor_metabox() {
 			'id'   => 'wpcsp_donor_twitter',
 			'type' => 'text',
 		)
-	);	
+	);
 }
-
 
 /**
  * Generate sponsor metaboxes.


### PR DESCRIPTION
This adds a Twitter handle field to the donors meta box in the donors custom post type. I'll be honest, I didn't test it anywhere 🤠 but considering it's a single meta field it's probably unlikely to break anything... You may want to test if you think the code doesn't look right. 😆

## Checklist:
- [ ] My code is tested. 
- [X] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [X] My code follows the WordPress coding standards.
- [X] My code has proper inline documentation.
