### PR TITLE
Proofreading edits to being-a-colourblind-designer-en.vtt

### DIFF
--- a/src/assets/captions/2025/being-a-colourblind-designer-en.vtt
+++ b/src/assets/captions/2025/being-a-colourblind-designer-en.vtt
@@ -2406,7 +2406,7 @@ to segue over to tools.
 
 00:39:58.688 --> 00:40:02.279
 I remember reading in the chat
-while the Simulive was playing,
+while the simulive was playing,
 
 00:40:02.280 --> 00:40:04.619
 you had recommended


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
1. Applies following UK spellings since speaker is British and slides use British English:

- colour, colourblind, colour blindness (2 words)
- greyscale
- realise, summarise
- licence- labelling
- theatre
- favourite

2. Adjusts start/end times for following captions:

- 224: caption ("Yes") was appearing ahead of speech. Change start from 00:13:08.100 to 00:13:10.000; change end from 00:13:09.100 to 00:13:11.500

- 262: speaker started saying the phrase ("the ability to make...") quite a bit before caption was displayed, albeit with some hesitation/stuttering. Change start time from 00:15:40.500 to 00:15:37.200

- 316: insert "you'll know that" at start (fills gap in captions and matches speech). Change start time from 00:19:04.320 to 00:19:01.154 to include insertion within caption

- 357: insert "Well," at start. Change start time from 00:21:43.050 to 00:21:42.837 to include insertion within caption

- 528: caption ("being colourblind and...") was lagging behind speech. Change start time from 00:32:30.060 to 00:32:28.923- 595: change end time of 595 ("It's incredibly difficult...") from 00:35:59.747 to 00:35:58.999 to allow "So," to be inserted at start of next caption 596

- 596: Insert "So," at start to convey that the speaker is summarising the point he is making. Change start time from 00:36:00.780 to 00:35:59.000. Change ", it'd" to "would". Resulting caption: "So, just adding some iconography to that button would be great."

3. Merges original captions 395 and 396 into single caption to make more sense and to match speech: "So, what can you do with these, particularly these four frustrations? Firstly, ". Sets end time of new combined caption to end time of original caption 396. (Can't moves "firstly" to start of following caption, as I don't know the exact timestamp for "Firstly")

4. Adds new caption before caption 660. Start 00:39:17.230, end 00:39:20.849: "Matt: Yes, so there's definitely..." (indicates speaker is thinking; previously there was a 3 second gap in the captions, even though speaker was saying something)

5. Adds new caption ("How do you...?") before caption 708. Start 00:41:49.561, end 00:41:51.499 (conveys puzzlement about a colourblind person using tools to simulate colour blindness. Previously there was a 2 second gap in captions, even though speaker was talking)

6. Adds a few bridging words/fillers and interjections considered to be functional, e.g. And, but, so, right, well

7. Applies a few other tweaks to spelling and punctuation in sponsors' roll, presentation and Q&A

## How Has This Been Tested?
Not yet - updated vtt needs to be deployed to be able to test changes

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Spelling and punctuation corrections
Some caption timings adjusted
2 new captions added
2 existing captions merged

## Checklist:
- [ ] My code is tested.
- [ ] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [ ] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
