### PR TITLE
A few more proofreading corrections to being-a-colourblind-designer-en.vtt

### DIFF
--- a/src/assets/captions/2025/being-a-colourblind-designer-en.vtt
+++ b/src/assets/captions/2025/being-a-colourblind-designer-en.vtt
@@ -97,11 +97,8 @@ NerdPress,
 00:01:13.020 --> 00:01:14.300
 Osom Studio,
 
-00:01:14.340 --> 00:01:15.339
-OZeWAI –
-
-00:01:15.340 --> 00:01:18.434
-Australian Web
+00:01:14.340 --> 00:01:18.434
+OZeWAI – Australian Web
 Accessibility Initiative,
 
 00:01:18.780 --> 00:01:20.219
@@ -332,8 +329,8 @@ I'll put it to you.
 00:04:56.979 --> 00:04:58.830
 What number is this?
 
-00:04:59.653 --> 00:05:05.760
-Is it A) 21, B) 74, or even, 
+00:04:59.653 --> 00:05:07.000
+Is it A) 21, B) 74, or even,
 "There's a number, question mark"?
 
 00:05:08.780 --> 00:05:10.460
@@ -343,7 +340,7 @@ What do we think?
 It's actually 74.
 
 00:05:16.060 --> 00:05:18.939
-Now, I say 'actually',
+Now, I say "actually",
 because I can't see that number.
 
 00:05:18.940 --> 00:05:21.059
@@ -877,7 +874,7 @@ How do you do that?"
 It's fairly easy,
 and I'll explain why.
 
-00:14:37.800 --> 00:14:41.529
+00:14:33.500 --> 00:14:41.529
 Imagine an older person
 designing a walking aid,
 
@@ -1009,7 +1006,7 @@ what it's like to feel
 excluded by the design,
 
 00:17:01.590 --> 00:17:06.240
-the presentation, the whatever it is 
+the presentation, the whatever it is
 might be in front of me.
 
 00:17:06.450 --> 00:17:10.350
@@ -1213,8 +1210,7 @@ I wouldn't be designing
 things like this.
 
 00:20:40.740 --> 00:20:44.469
-Maybe many of you would
-do something so complex.
+Maybe many of you wouldn't do something so complex.
 
 00:20:44.730 --> 00:20:46.349
 This was really an example
@@ -1264,8 +1260,7 @@ I get as a colourblind designer
 on a fairly regular basis,
 
 00:21:27.990 --> 00:21:32.790
-and the first one being,
-see corrections in red.
+and the first one being, "See corrections in red".
 
 00:21:33.930 --> 00:21:37.580
 Red, obviously, synonymous
@@ -1309,8 +1304,8 @@ Another frustration
 is around comments
 
 00:22:14.720 --> 00:22:17.919
-like it's not that serious,
-colour blindness.
+like "it's not that serious,
+colour blindness".
 
 00:22:17.920 --> 00:22:23.340
 There's a huge spectrum of visual
@@ -1367,11 +1362,11 @@ this conversation
 in a really positive way.
 
 00:23:07.620 --> 00:23:11.279
-And fourthly, as you can see
-from this graph, 
+And fourthly, "As you can see
+from this graph...",
 
 00:23:11.280 --> 00:23:14.216
-again I'll touch on a solution in a moment, 
+again I'll touch on a solution in a moment,
 
 00:23:14.970 --> 00:23:18.330
 but regardless of what
@@ -1417,7 +1412,7 @@ That is an absolute frustration.
 It's incredibly, incredibly common.
 
 00:24:07.780 --> 00:24:14.009
-So, what can you do with these, particularly 
+So, what can you do with these, particularly
 these four frustrations? Firstly,
 
 00:24:14.010 --> 00:24:16.820
@@ -1567,8 +1562,8 @@ and colour blindness being absolutely
 part of that conversation, too.
 
 00:26:46.530 --> 00:26:49.862
-Then lastly, as you
-can see from the graph,
+Then lastly, "As you
+can see from the graph...",
 
 00:26:51.390 --> 00:26:53.159
 there are quite a few solutions.


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
# 2nd set of proofreading edits to being-a-colourblind-designer-en.vtt

1. Combine captions 31 and 32 into 1 caption (31): "OZeWAI – Australian Web Accessibility Initiative,". Delete former caption 32.

2. 97 (new number, was 98) increase end time from 00:05:05.760 to 00:05:07.000 (caption was finishing before speech)

3. 100 (was 101): "actually" with double quotes instead of single quotes

4. 246 (was 247): change start time from 00:14:37.800 to 00:14:33.500 (caption was lagging speech)

5. 338 (was 339): changed "would" to "wouldn't" (difficult to tell what speaker is saying, but I think he says "wouldn't" and this makes more sense, bearing in mind the audience, who understand the need to make designs accessible)

6. 352 (was 353), 364 (was 365), 380 (was 381), 434 (was 433): added quotation marks around each 'frustration' to make it clear these are subtopics the speaker is talking about. This is how the same subtopics are handled in later captions, and it also matches the presentation slides. Without quotation marks, everyone time I saw the phrase 'as you can see from the graph', I kept looking for a graph in the slides!

## How Has This Been Tested?
Updated VTT needs to be deployed to server in order to test

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Punctuation, word correction, adjustment to caption timings, 2 captions combined into 1

## Checklist:
- [ ] My code is tested.
- [ ] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [ ] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
