### PR TITLE
2nd set of proofreading edits for demystifying screenreaders VTT

### DIFF
--- a/src/assets/captions/2025/demystifying-screen-readers-your-guided-intro-to-manual-accessibility-testing-for-wordpress-sites-en.vtt
+++ b/src/assets/captions/2025/demystifying-screen-readers-your-guided-intro-to-manual-accessibility-testing-for-wordpress-sites-en.vtt
@@ -2401,7 +2401,7 @@ United States.
 For dialogues, dialogue,
 "Are you sure you want
 
-00:36:29.581 --> 00:36:30.631
+00:36:29.581 --> 00:36:31.999
 to delete this item, apostrophe?"
 
 00:36:32.191 --> 00:36:34.470
@@ -3043,7 +3043,7 @@ There's a lot of similarities,
 
 00:47:02.873 --> 00:47:12.999
 but it's pretty much what I said. 
-JAWS is going to try to inject things into the...
+JAWS is going to inject things into the...
 
 00:47:13.415 --> 00:47:17.625
 You're going to have a difference


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
914 ropes with lower case "r"

917 split caption over 2 lines using carriage return in transcript sorter (did the same for a few other captions). However, when the VTT generator was run, the caption was still on 1 line, so the generator doesn't seem to have respected the carriage return. Now trying to add carriage return directly in VTT to see if that works any better.

General
- added voice marks to all speaker names

## How Has This Been Tested?
Not yet - need new VTT to be deployed first

## Screenshots (jpeg or gifs if applicable):

## Types of changes
voicemarks, spelling, formatting of captions

## Checklist:
- [ ] My code is tested.
- [ ] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [ ] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
