### PR TITLE
Proofreading edits to vtt for Audio Accessibility in Wordpress

### DIFF
--- a/src/assets/captions/2025/audio-accessibility-in-wordpress-en.vtt
+++ b/src/assets/captions/2025/audio-accessibility-in-wordpress-en.vtt
@@ -358,7 +358,7 @@ What you see on the right side
 is a screenshot of a website,
 
 00:06:08.895 --> 00:06:12.974
-my website, soundklapp,
+my website, Soundklapp,
 with an overlay solution.
 
 00:06:13.335 --> 00:06:16.575
@@ -1630,7 +1630,7 @@ If you want to have
 a more comfortable solution,
 
 00:31:06.854 --> 00:31:10.454
-you have to use plug-ins
+you have to use plugins
 like the Audio Player Block,
 
 00:31:10.575 --> 00:31:13.003
@@ -1795,7 +1795,7 @@ Then you have embedded it
 with the native Gutenberg block
 
 00:34:29.654 --> 00:34:31.245
-or with a plug-in,
+or with a plugin,
 
 00:34:32.504 --> 00:34:37.305
 and, nice to have, you have provide
@@ -1859,7 +1859,7 @@ You have automated tools like WAVE,
 and then you have some testing software,
 
 00:35:55.925 --> 00:36:03.645
-you can use a WordPress plug-in
+you can use a WordPress plugin
 or you have external testing software.
 
 00:36:03.885 --> 00:36:07.455
@@ -2134,7 +2134,7 @@ I have to check, sorry.
 <v Alexandra> That's okay.
 
 00:40:43.111 --> 00:40:48.488
-I wrote down SoundKlapp
+I wrote down Soundklapp
 for the anonymous person
 
 00:40:48.508 --> 00:40:50.645


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
Sponsors' roll - punctuation and spelling edits

18-19: merge into 1 caption and delete 19

43 and 556 (was 555): replace & with "&amp;" in Q&A

70: "band websites", not "banned websites"!

228: change start time from 00:13:04.414 to 00:13:02.834. Insert "but at start

322: change start time from 00:20:01.504 to 00:20:00.935. Add "So," at start.

363: change start time from 00:22:49.324 to 00:22:47.765. Add "But" at start.

408: "this red microphone", not "this recording microphone"

After 429: add new caption, start 00:27:37.425, end 00:27:42.999: "with only one picture..."

454 (was 453): change "WordPress media tick" to "WordPress médiathèque [Media Library],"

478 (was 477): change start time from 00:30:58.245 to 00:30:57.500. Add "But" at start.

483 (was 482): Add "enable or": "With this version only you can enable or disable the playback speed adjustment options," (as per slides)

488 (was 487): change "with some things who are not going to say," to "with some things ... to say,

511 (was 510): "pro version", not "raw version"

534 (was 533): "sounds? Don't work with so much background sounds."

749 (was 748): replace word "hashtag" with symbol "#"

755-6 (was 754-5): title case for "Accessibility Lawsuits and WordPress: The Violations Every Business Needs to Know"

757 (was 756): Vanessa Tillemans (not Tillman)

General:
- replaces speakers' names with voicemarks
- use first name only for speakers' names
- adds speech marks to audience questions where question was read out verbatim

## How Has This Been Tested?
Unable to test until updated VTT has been deployed

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Spelling and punctuation, caption timings, merge 2 captions into 1, add 1 new caption

## Checklist:
- [ ] My code is tested.
- [ ] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [ ] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
