### PR TITLE
proofreading edits for vtt for continuous-ai

### DIFF
--- a/src/assets/captions/2025/continuous-ai-for-accessibility-leveraging-tools-for-faster-more-inclusive-development-en.vtt
+++ b/src/assets/captions/2025/continuous-ai-for-accessibility-leveraging-tools-for-faster-more-inclusive-development-en.vtt
@@ -1,7 +1,7 @@
 ﻿WEBVTT
 
 00:00:00.780 --> 00:00:02.630
->> ANNOUNCER: Thank you to our sponsors.
+<v ANNOUNCER> Thank you to our sponsors.
 
 00:00:03.480 --> 00:00:05.849
 Platinum Sponsor: Gravity Forms.
@@ -43,7 +43,7 @@ manage, and grow their businesses.
 Gold Sponsors: Ally Web Accessibility,
 
 00:00:42.630 --> 00:00:45.329
-Equalize Digital Websites for Everyone,
+Equalize Digital - websites for everyone,
 
 00:00:46.079 --> 00:00:47.079
 GoDaddy,
@@ -54,11 +54,8 @@ GreenGeeks Web Hosting, Yoast.
 00:00:51.420 --> 00:00:53.520
 Silver Sponsors: AAArdvark,
 
-00:00:53.909 --> 00:00:55.350
-CodeGeek – Your Vision.
-
-00:00:55.380 --> 00:00:56.729
-Our Talent, One Team,
+00:00:53.909 --> 00:00:56.729
+CodeGeek – Your Vision, Our Talent, One Team.
 
 00:00:57.359 --> 00:01:00.750
 Kinetic Iris, Kinsta, Pressable,
@@ -105,7 +102,7 @@ Termageddon,
 WebYes.
 
 00:01:32.551 --> 00:01:36.779
->> MADLIN NTI: Welcome
+<v MADLIN NTI> Welcome
 to WordPress Accessibility Day 2025.
 
 00:01:37.120 --> 00:01:38.790
@@ -169,7 +166,7 @@ including software.
 
 00:02:27.701 --> 00:02:31.391
 Please feel free to add your questions
-in the Zoom Q&A section.
+in the Zoom Q&amp;A section.
 
 00:02:31.653 --> 00:02:33.910
 We will answer them
@@ -293,7 +290,7 @@ that it's about integrating
 automation, AI,
 
 00:04:13.061 --> 00:04:14.649
-and then most importantly,
+and then, most importantly,
 
 00:04:14.650 --> 00:04:17.451
 human review into development workflows.
@@ -594,10 +591,10 @@ leveraging continuous AI concepts
 to help multiply your efforts.
 
 00:08:26.920 --> 00:08:29.261
-We call the flow of the tool find,
+We call the flow of the tool "find,
 
 00:08:29.380 --> 00:08:33.909
-file, fix, leveraging already
+file, fix", leveraging already
 available tools to find
 
 00:08:33.910 --> 00:08:35.560
@@ -631,7 +628,7 @@ the find component.
 
 00:08:56.770 --> 00:09:00.280
 Right now, we use GitHub Actions
-along with axe-core for quick,
+along with Axe-core for quick,
 
 00:09:00.281 --> 00:09:01.300
 reliable checks.
@@ -720,12 +717,12 @@ because they don't know what's going on.
 
 00:10:13.320 --> 00:10:17.187
 It's really your job as that expert,
-as that person with that knowledge,
+as that person with that experience,
 
 00:10:17.551 --> 00:10:18.851
 to bring them up with you,
 
-00:10:19.381 --> 00:10:22.261
+00:10:19.381 --> 
 to pass that knowledge to the future.
 
 00:10:22.951 --> 00:10:25.741
@@ -765,7 +762,7 @@ be able to pick this up and get moving?
 That's what we want.
 
 00:10:49.231 --> 00:10:50.790
-We want to unlock everybody,
+We want to unlock everybody:
 
 00:10:50.791 --> 00:10:51.791
 humans
@@ -1282,7 +1279,7 @@ I guess you could look at it.
 It's from a library called ️AstroWind.
 
 00:17:58.261 --> 00:17:59.610
-It's not WordPress. I'm so sorry.
+It's not in WordPress. I'm so sorry.
 
 00:17:59.610 --> 00:18:02.070
 It's because I wanted
@@ -1394,21 +1391,21 @@ a version that you're working against
 
 00:19:27.636 --> 00:19:30.031
 because if there are
-breaking changes,
+breaking changes—
 
 00:19:30.140 --> 00:19:31.141
-this isn't WordPress.
+this isn't WordPress,
 
 00:19:31.141 --> 00:19:33.540
-It's not backwards compatible forever.
+it's not backwards compatible forever—
 
 00:19:34.051 --> 00:19:35.581
-With breaking changes,
+with breaking changes,
 you want to make sure
 
 00:19:35.581 --> 00:19:38.820
-that you're not surprised by that,
-by not pitting yourself
+that you're not surprised by that
+by not pinning yourself
 
 00:19:38.821 --> 00:19:40.050
 to a specific version.
@@ -1438,7 +1435,7 @@ to open issues in,
 
 00:20:04.170 --> 00:20:07.470
 which can be a repository different
-from the one you're scanning it out of,
+from the one you're running it out of,
 
 00:20:07.470 --> 00:20:08.470
 like I said.
@@ -1447,7 +1444,7 @@ like I said.
 Let's say you have a public site,
 
 00:20:10.919 --> 00:20:13.569
-maybe you're running the scanner
+and maybe you're running the scanner
 from the public repo,
 
 00:20:13.590 --> 00:20:17.581
@@ -1480,7 +1477,7 @@ and then there's a cache key.
 The reason for the cache key--
 
 00:20:37.122 --> 00:20:39.271
-This can be whatever you want to call it.
+and this can be whatever you want to call it.
 
 00:20:39.331 --> 00:20:42.780
 I named it for the name of my repo.
@@ -1519,7 +1516,7 @@ You'll be able to navigate to the Action,
 
 00:21:07.441 --> 00:21:11.071
 there will be a dropdown for run workflow,
-where you've set a couple of options,
+where you set a couple of options,
 
 00:21:11.071 --> 00:21:13.221
 and then you can run
@@ -1569,7 +1566,7 @@ on production URLs.
 That's what you can do as well.
 
 00:21:47.101 --> 00:21:50.070
-It's not just on-demand;
+It's not just on-demand,
 run the scanner, which,
 
 00:21:50.071 --> 00:21:52.681
@@ -1605,8 +1602,8 @@ on any number of events available to you
 00:22:14.880 --> 00:22:15.880
 at GitHub.
 
-00:22:17.610 --> 00:22:18.760
-I've run this workflow.
+00:22:16.300 --> 00:22:18.760
+So, I've run this workflow.
 
 00:22:19.060 --> 00:22:22.864
 I'm not going to do this live
@@ -1721,7 +1718,7 @@ to Copilot.
 I've got some labels.
 
 00:23:54.470 --> 00:23:57.900
-Again, we've got to think
+Again, we've got to think,
 about we've got to add
 
 00:23:57.901 --> 00:23:59.970
@@ -1847,15 +1844,15 @@ of the following: Element has
 insufficient color contrast of 1.83
 
 00:25:44.611 --> 00:25:49.181
-(foreground color: #bfbfbf,
+{foreground color: #bfbfbf,
 background color: #fff,
 
 00:25:49.371 --> 00:25:53.370
-font size: 15.0 points (20 pixels),
+font size: 15.0 points / 20 pixels,
 font weight: normal.
 
 00:25:53.630 --> 00:25:57.070
-Expected contrast ratio of 4.5:1.
+Expected contrast ratio of 4.5:1.}
 
 00:25:57.721 --> 00:26:01.050
 Then it actually gives me
@@ -1944,7 +1941,7 @@ has worked on is ensuring
 
 00:27:08.971 --> 00:27:12.571
 that we're at least testing to make
-sure that it's including all text
+sure that it's including alt text
 
 00:27:13.081 --> 00:27:14.231
 with these screenshots.
@@ -2005,8 +2002,7 @@ It's able to take a look
 through the framework
 
 00:27:58.710 --> 00:28:02.670
-and make not just file
-name-based decisions
+and make not just filename-based decisions
 
 00:28:02.671 --> 00:28:06.570
 about what's going on, but it's able
@@ -2137,13 +2133,13 @@ it shows me it's made just two
 targeted changes
 
 00:29:44.600 --> 00:29:47.730
-to these color text-muted.
+to these color text-muted...
 
 00:29:48.080 --> 00:29:49.180
-They're not variables.
+they're not variables,
 
 00:29:49.231 --> 00:29:50.431
-Whatever they're called.
+whatever they're called.
 
 00:29:50.941 --> 00:29:54.241
 It's made changes to these
@@ -2232,9 +2228,12 @@ to the machine?
 00:30:54.741 --> 00:30:55.760
 How am I going to deal with this?
 
-00:30:55.760 --> 00:30:59.410
+00:30:55.760 --> 00:30:58.999
 What if I hated this pull request
 and I didn't want to merge it right now?
+
+00:30:59.000 --> 00:31:00.980
+Well,
 
 00:31:00.981 --> 00:31:03.140
 I've got this other color contrast issue.
@@ -2280,7 +2279,7 @@ There's a foreground color
 of a blue-200 variant
 
 00:31:33.411 --> 00:31:36.161
-for the color variables
+from the color variables
 and a background color of white.
 
 00:31:36.590 --> 00:31:43.272
@@ -2377,7 +2376,7 @@ better visual hierarchy while maintaining
 
 00:33:00.050 --> 00:33:04.430
 excellent accessibility
-(16.38:1 contrast ratio).
+{16.38:1 contrast ratio}.
 
 00:33:04.790 --> 00:33:09.201
 This is less prominent than blue-50,
@@ -2803,19 +2802,19 @@ I mentioned this previously,
 you might tell,
 
 00:38:52.280 --> 00:38:55.371
-"How do you customize what the AI
-knows about your code base?
+"how do you customize what the AI
+knows about your code base?"
 
 00:38:57.441 --> 00:39:01.281
 If we keep going back to this parallel
 of it's like a newer developer,
 
 00:39:01.361 --> 00:39:04.111
-how do you onboard newer developers
+"how do you onboard newer developers
 into your code base,
 
 00:39:04.121 --> 00:39:06.049
-especially when it's a large one?
+especially when it's a large one?"
 
 00:39:06.251 --> 00:39:07.851
 If I think about WordPress core,
@@ -2903,7 +2902,7 @@ We're able to look at it and go,
 "Okay, I see the type of fix
 
 00:40:12.380 --> 00:40:14.599
-that's made in my theme,
+it's made in my theme,
 but now I understand
 
 00:40:14.600 --> 00:40:16.500
@@ -3269,16 +3268,16 @@ and give us lots of feedback.
 I genuinely want to hear it.
 
 00:44:51.151 --> 00:44:54.470
-I'll join you now live for a Q&A,
+I'll join you now live for a Q&amp;A,
 and I'll catch you online.
 
 00:44:57.580 --> 00:45:02.261
-Madlin Nti: Thank you so much,
+<v Madlin> Thank you so much,
 Helen, for that presentation.
 
 00:45:02.600 --> 00:45:08.810
 Do remember that you can put
-in your Q&A in the Q&A section.
+in your Q&amp;A in the Q&amp;A section.
 
 00:45:09.260 --> 00:45:11.243
 Let's get right into it.
@@ -3289,10 +3288,10 @@ an anonymous attendee,
 
 00:45:16.340 --> 00:45:19.639
 and they're asking,
-do you have any recommendations
+"Do you have any recommendations
 
 00:45:19.640 --> 00:45:23.359
-for tools and plug-ins to help
+for tools and plugins to help
 prevent accessibility
 
 00:45:23.360 --> 00:45:25.922
@@ -3303,13 +3302,13 @@ Is there a way to prevent
 inaccessible and/or large PDFs,
 
 00:45:30.620 --> 00:45:32.659
-wrong heading levels, etc.
+wrong heading levels, etc."
 
 00:45:32.660 --> 00:45:35.553
 What do you have to say about that?
 
 00:45:36.700 --> 00:45:37.859
-Helen Hou-Sandi: I went ahead
+<v Helen> I went ahead
 
 00:45:37.860 --> 00:45:40.159
 and I answered
@@ -3395,21 +3394,21 @@ the Slack as well.
 Happy to take it there.
 
 00:46:34.850 --> 00:46:36.649
-Madlin: Sure thing. Thank you.
+<v Madlin> Sure thing. Thank you.
 
 00:46:36.650 --> 00:46:38.719
 Emilio Dominguez is asking,
 
 00:46:38.720 --> 00:46:42.199
-what data does GitHub
+"What data does GitHub
 use to train the models?
 
 00:46:42.200 --> 00:46:47.198
 How can we know they are accurately
-fixing or addressing issues?
+fixing or addressing issues?"
 
 00:46:48.500 --> 00:46:49.909
-Helen: GitHub does not actually train
+<v Helen> GitHub does not actually train
 
 00:46:49.910 --> 00:46:52.309
 the models directly
@@ -3433,7 +3432,7 @@ like the day that they're announced.
 We partner up.
 
 00:47:05.980 --> 00:47:10.899
-We've got like Cloud 4.5 as a beta,
+We've got like Claude 4.5 as a beta,
 the day that they share it.
 
 00:47:10.940 --> 00:47:14.119
@@ -3569,7 +3568,7 @@ Those are the things
 that we're able to do internally.
 
 00:48:55.100 --> 00:48:56.869
-Madlin: Thank you so much, Helen,
+<v Madlin> Thank you so much, Helen,
 
 00:48:56.870 --> 00:49:00.079
 for such an insightful presentation.
@@ -3581,11 +3580,11 @@ We're grateful to have you here.
 Thank you so much.
 
 00:49:04.540 --> 00:49:05.479
-Helen: Thank you for having me.
+<v Helen> Thank you for having me.
 
 00:49:05.480 --> 00:49:07.489
 I'm sorry we're short on time
-for Q&A, but like I said,
+for Q&amp;A, but like I said,
 
 00:49:07.490 --> 00:49:08.989
 I'm actually in Slack now.
@@ -3606,7 +3605,7 @@ Looking forward to any feedback
 you all might have.
 
 00:49:18.370 --> 00:49:19.639
-Madlin: Great. Thank you.
+<v Madlin> Great. Thank you.
 
 00:49:19.640 --> 00:49:22.639
 Thank you for attending
@@ -3641,7 +3640,7 @@ You can enter to win
 a T-shirt while you're there.
 
 00:49:50.270 --> 00:49:53.960
-Stay tuned for Joe A. Simpson Jr.
+Stay tuned for Joe A Simpson Jr
 
 00:49:56.420 --> 00:49:59.209
 on his presentation


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
Sponsors' roll - punctuation and spelling edits

17-18 Combine into 1 caption, delete 18

200 "experience", not "knowledge"

395 "pinning", not "pitting"

403 "running", not "scanning"

426 "you", not "you've"

450 change start time from 00:22:17.610 to 00:22:16.300. Insert "So," at start

519-521 replaced parentheses with curly brackets, since anything in () is assumed to be a speaker's voice and appears as a new paragraph in the transcript. Didn't use square brackets as anything in [] appears in bold in the transcript. Also, changed "15.0 points (20 pixels)" to "15.0 points / 20 pixels" for the same reasons.

546 "alt text", not "all text"

563 "filename-based", not "file name-based"

628 Change end time from 00:30:59.410 to 00:30:58.999

After 628: insert new caption, start 00:30:59.000, end 00:31:00.980: "Well,"

641 "from the color variables", not "for the color variables"

668 replaced parentheses with curly brackets in "{16.38:1 contrast ratio}" for same reason as 519-521 above

816 "it's made", not "that's made"

925 "plugins"

964 "Claude 4.5", not "Cloud 4.5"

General:
- replaces speakers' names with voicemarks
- use first name only for speakers' names
- adds speech marks to audience questions where question was read out verbatim
- replace "&" with "&amp;" in Q&A

## How Has This Been Tested?
Need updated vtt to be deployed before it can be tested

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Spelling, punctuation, caption timings, caption merges, additional captions

## Checklist:
- [ ] My code is tested.
- [ ] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [ ] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
