### PR TITLE
replaces space after voice tags + adjusts timing for 2 consecutive ca…

### DIFF
--- a/src/assets/captions/2025/continuous-ai-for-accessibility-leveraging-tools-for-faster-more-inclusive-development-en.vtt
+++ b/src/assets/captions/2025/continuous-ai-for-accessibility-leveraging-tools-for-faster-more-inclusive-development-en.vtt
@@ -1,7 +1,7 @@
 ﻿WEBVTT
 
 00:00:00.780 --> 00:00:02.630
-<v ANNOUNCER>Thank you to our sponsors.
+<v ANNOUNCER> Thank you to our sponsors.
 
 00:00:03.480 --> 00:00:05.849
 Platinum Sponsor: Gravity Forms.
@@ -102,7 +102,7 @@ Termageddon,
 WebYes.
 
 00:01:32.551 --> 00:01:36.779
-<v MADLIN NTI>Welcome
+<v MADLIN NTI> Welcome
 to WordPress Accessibility Day 2025.
 
 00:01:37.120 --> 00:01:38.790
@@ -177,7 +177,7 @@ Use the chat to connect
 with other attendees.
 
 00:02:39.671 --> 00:02:40.780
-<v HELEN HOU-SANDÍ>Hello, everyone.
+<v HELEN HOU-SANDÍ> Hello, everyone.
 
 00:02:40.780 --> 00:02:42.270
 My name is Helen Hou-Sandí.
@@ -2232,10 +2232,10 @@ How am I going to deal with this?
 What if I hated this pull request
 and I didn't want to merge it right now?
 
-00:30:59.000 --> 00:31:00.980
+00:30:59.000 --> 00:31:00.000
 Well,
 
-00:31:00.981 --> 00:31:03.140
+00:31:00.500 --> 00:31:03.140
 I've got this other color contrast issue.
 
 00:31:03.351 --> 00:31:04.619
@@ -3272,7 +3272,7 @@ I'll join you now live for a Q&amp;A,
 and I'll catch you online.
 
 00:44:57.580 --> 00:45:02.261
-<v Madlin>Thank you so much,
+<v Madlin> Thank you so much,
 Helen, for that presentation.
 
 00:45:02.600 --> 00:45:08.810
@@ -3308,7 +3308,7 @@ wrong heading levels, etc."
 What do you have to say about that?
 
 00:45:36.700 --> 00:45:37.859
-<v Helen>I went ahead
+<v Helen> I went ahead
 
 00:45:37.860 --> 00:45:40.159
 and I answered
@@ -3394,7 +3394,7 @@ the Slack as well.
 Happy to take it there.
 
 00:46:34.850 --> 00:46:36.649
-<v Madlin>Sure thing. Thank you.
+<v Madlin> Sure thing. Thank you.
 
 00:46:36.650 --> 00:46:38.719
 Emilio Dominguez is asking,
@@ -3408,7 +3408,7 @@ How can we know they are accurately
 fixing or addressing issues?"
 
 00:46:48.500 --> 00:46:49.909
-<v Helen>GitHub does not actually train
+<v Helen> GitHub does not actually train
 
 00:46:49.910 --> 00:46:52.309
 the models directly
@@ -3568,7 +3568,7 @@ Those are the things
 that we're able to do internally.
 
 00:48:55.100 --> 00:48:56.869
-<v Madlin>Thank you so much, Helen,
+<v Madlin> Thank you so much, Helen,
 
 00:48:56.870 --> 00:49:00.079
 for such an insightful presentation.
@@ -3580,7 +3580,7 @@ We're grateful to have you here.
 Thank you so much.
 
 00:49:04.540 --> 00:49:05.479
-<v Helen>Thank you for having me.
+<v Helen> Thank you for having me.
 
 00:49:05.480 --> 00:49:07.489
 I'm sorry we're short on time
@@ -3605,7 +3605,7 @@ Looking forward to any feedback
 you all might have.
 
 00:49:18.370 --> 00:49:19.639
-<v Madlin>Great. Thank you.
+<v Madlin> Great. Thank you.
 
 00:49:19.640 --> 00:49:22.639
 Thank you for attending


### PR DESCRIPTION
…ptions

<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
Adds space after voice tags. Without a space, final output has no space between speaker and text, e.g. <v Mike>Hello world! becomes (Mike)Hello world!

628 ("Well"): change end time from 00:31:00.980 to 00:31:00.000

629: change start time from 00:31:00.981 to 00:31:00.500

## How Has This Been Tested?
To be tested after updated VTT has been deployed

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Caption timings, voice tags

## Checklist:
- [ ] My code is tested.
- [ ] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [ ] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
