### PR TITLE
proofreading edits to vtt for Making Gutenberg Blocks Accessible

### DIFF
--- a/src/assets/captions/2025/making-gutenberg-blocks-accessible-practical-techniques-with-ai-and-devtools-en.vtt
+++ b/src/assets/captions/2025/making-gutenberg-blocks-accessible-practical-techniques-with-ai-and-devtools-en.vtt
@@ -1,7 +1,7 @@
 ﻿WEBVTT
 
 00:00:00.667 --> 00:00:03.369
->> SPEAKER: Thank you
+<v ANNOUNCER> Thank you
 to our sponsors.
 
 00:00:03.370 --> 00:00:06.271
@@ -9,10 +9,10 @@ Platinum Sponsor: Gravity Forms.
 
 00:00:06.272 --> 00:00:10.409
 Build accessible, powerful WordPress
-forms with Gravity Forms.
+forms with Gravity Forms,
 
 00:00:10.410 --> 00:00:15.408
-Flexible tools for creators,
+flexible tools for creators,
 developers, and teams of all sizes.
 
 00:00:15.482 --> 00:00:18.050
@@ -31,7 +31,7 @@ Platinum Sponsor: Woo.
 
 00:00:29.029 --> 00:00:31.830
 WooCommerce is the
-open-source e-commerce platform
+open source e-commerce platform
 
 00:00:31.831 --> 00:00:35.701
 built on WordPress,
@@ -41,87 +41,83 @@ helping merchants worldwide sell,
 manage, and grow their businesses.
 
 00:00:38.872 --> 00:00:42.208
-Gold sponsors: Ally,
-web accessibility.
+Gold sponsors: Ally Web Accessibility,
 
 00:00:42.509 --> 00:00:45.845
-Equalize Digital – websites for everyone
+Equalize Digital – websites for everyone,
 
 00:00:45.979 --> 00:00:47.180
-GoDaddy.
+GoDaddy, 
 
 00:00:47.347 --> 00:00:49.348
-GreenGeeks, web hosting.
+GreenGeeks Web Hosting,
 
 00:00:49.349 --> 00:00:50.550
 Yoast.
 
 00:00:51.317 --> 00:00:53.786
-Silver sponsors: AAArdvark.
+Silver sponsors: AAArdvark,
 
-00:00:53.787 --> 00:00:55.287
-CodeGeek – Your vision.
-
-00:00:55.288 --> 00:00:57.222
-Our talent, One team.
+00:00:53.787 --> 00:00:57.222
+CodeGeek – Your vision, Our talent, One team.
 
 00:00:57.223 --> 00:00:58.824
-Kinetic Iris.
+Kinetic Iris,
 
 00:00:58.909 --> 00:00:59.958
-Kinsta.
+Kinsta,
 
 00:00:59.959 --> 00:01:01.160
-Pressable.
+Pressable,
 
 00:01:01.161 --> 00:01:02.762
-Second Melody.
+Second Melody,
 
 00:01:03.363 --> 00:01:06.932
-Bronze sponsors: 9 Planets Hosting.
+Bronze sponsors: 9 Planets Hosting,
 
 00:01:06.933 --> 00:01:08.101
-Engage.
+Engage,
 
 00:01:08.168 --> 00:01:09.769
-Draw Attention.
+Draw Attention,
 
 00:01:09.941 --> 00:01:11.437
-Multidots.
+Multidots,
 
 00:01:11.541 --> 00:01:12.971
-NerdPress.
+NerdPress,
 
 00:01:12.972 --> 00:01:14.339
-Osom Studio.
+Osom Studio, 
 
 00:01:14.340 --> 00:01:18.278
 OZeWAI – Australian
-Web Accessibility Initiative.
+Web Accessibility Initiative,
 
 00:01:18.645 --> 00:01:20.145
-Progress Planner.
+Progress Planner,
 
 00:01:20.146 --> 00:01:21.435
-QualityLogic.
+QualityLogic,
 
 00:01:21.815 --> 00:01:25.250
-Sharp, Simply Schedule Appointments.
+Sharp, Simply Schedule Appointments,
 
 00:01:25.251 --> 00:01:26.453
-SiteGround.
+SiteGround,
 
 00:01:26.486 --> 00:01:27.666
-StellarWP.
+StellarWP,
 
 00:01:28.346 --> 00:01:29.588
-Termageddon.
+Termageddon,
 
 00:01:29.746 --> 00:01:30.746
 WebYes.
 
 00:01:33.000 --> 00:01:36.936
->> ANNABELLE DRUMM: Welcome to WordPress
+<v ANNABELLE DRUMM> Welcome to WordPress
 Accessibility Day 2025.
 
 00:01:36.937 --> 00:01:40.306
@@ -136,7 +132,7 @@ Thank you for joining us
 
 00:01:43.506 --> 00:01:47.747
 for the presentation
-Making Gutenberg Blocks Accessible,
+Making Gutenberg Blocks Accessible:
 
 00:01:47.748 --> 00:01:53.687
 Practical Techniques with AI
@@ -146,7 +142,7 @@ and Dev Tools with Anam Hossain.
 Anam is a senior WordPress engineer
 
 00:01:56.089 --> 00:01:59.692
-at Multidots, a WordPress VIP agency
+at Multidots, a WordPress VIP agency,
 
 00:01:59.693 --> 00:02:01.494
 with over nine years of experience
@@ -159,15 +155,15 @@ and enterprise-level
 WordPress solutions.
 
 00:02:08.101 --> 00:02:11.370
-He specializes
+He specialises
 in Gutenberg block development,
 
 00:02:11.371 --> 00:02:14.507
-accessibility first design,
+accessibility-first design,
 and performance
 
 00:02:14.508 --> 00:02:17.109
-optimization with a strong focus
+optimisation with a strong focus
 
 00:02:17.110 --> 00:02:21.214
 on creating user-friendly
@@ -336,12 +332,12 @@ in your mindset as a developer,
 when you are writing your code,
 
 00:05:06.179 --> 00:05:12.651
-when you are writing in a div,
+when you are writing in a &lt;div&gt;,
 actually, you can think about
 
 00:05:12.652 --> 00:05:16.522
-should I write div
-or should I write button
+should I write &lt;div&gt;
+or should I write &lt;button&gt;
 
 00:05:16.523 --> 00:05:19.959
 because the functionality
@@ -351,8 +347,8 @@ of this section
 of this element will be button.
 
 00:05:22.662 --> 00:05:27.343
-Instead of writing div,
-we can actually writing some button.
+Instead of writing &lt;div&gt;,
+we can actually writing some &lt;button&gt;.
 
 00:05:27.400 --> 00:05:31.937
 When we are actually adding
@@ -453,17 +449,17 @@ Let's get started.
 
 00:06:55.488 --> 00:06:59.792
 In this session,
-I will cover some semantic HTML
+I will cover some semantic HTML;
 
 00:06:59.793 --> 00:07:01.861
-and ARIA roles, how ARIA roles
+and ARIA roles – how ARIA roles
 
 00:07:01.862 --> 00:07:04.463
 can be implemented
 or what is the main purpose
 
 00:07:04.464 --> 00:07:07.901
-of ARIA roles
+of ARIA roles;
 and keyboard accessibility,
 
 00:07:09.736 --> 00:07:13.175
@@ -479,17 +475,17 @@ or your site can be navigate
 order by order
 
 00:07:21.715 --> 00:07:23.682
-through the keyboard accessibility,
+through the keyboard accessibility;
 
 00:07:23.683 --> 00:07:26.162
-and some color contrast ratio.
+and some colour contrast ratio.
 
 00:07:27.888 --> 00:07:33.125
 If your site visitor
-having some color
+having some colour
 
 00:07:33.126 --> 00:07:34.680
-blindness or color ratio,
+blindness or colour issue,
 
 00:07:34.681 --> 00:07:38.796
 then when you are developing
@@ -500,19 +496,19 @@ or when you are designing your site,
 you must keep
 
 00:07:43.270 --> 00:07:45.971
-this color contrast
+this colour contrast
 ratio in your mind,
 
 00:07:45.972 --> 00:07:51.110
 because if you choose
-some wrong color for wrong people,
+some wrong colour for wrong people,
 
 00:07:51.111 --> 00:07:55.214
 then they might not get
 interested for your website.
 
 00:07:55.482 --> 00:07:57.850
-You must keep color contrast ratio
+You must keep colour contrast ratio
 
 00:07:57.851 --> 00:08:02.087
 when you are actually building
@@ -530,12 +526,12 @@ Alternative text
 is also the same level
 
 00:08:10.997 --> 00:08:13.365
-important as the color
+important as the colour
 contrast ratio,
 
 00:08:13.366 --> 00:08:17.569
 because it actually
-describe the image issue
+describe the image
 
 00:08:17.570 --> 00:08:19.004
 for the screen readers.
@@ -625,7 +621,7 @@ in the right place.
 
 00:09:48.261 --> 00:09:52.464
 When you are actually writing
-like the div or something like that,
+like the &lt;div&gt; or something like that,
 
 00:09:52.465 --> 00:09:57.436
 when you are actually developing
@@ -633,18 +629,18 @@ any page with a coding level.
 
 00:09:57.704 --> 00:10:01.040
 Instead of writing
-div for your header,
+&lt;div&gt; for your header,
 
 00:10:01.041 --> 00:10:05.477
-writing div for your navigation,
-writing div for your button,
+writing &lt;div&gt; for your navigation,
+writing &lt;div&gt; for your button,
 
 00:10:05.478 --> 00:10:09.548
 then you can actually
 think about this like,
 
 00:10:09.549 --> 00:10:11.450
-for the header, it can be header.
+for the header, it can be &lt;header&gt;.
 
 00:10:11.451 --> 00:10:12.530
 For the navigation,
@@ -654,22 +650,22 @@ if you are actually using
 writing navigation,
 
 00:10:15.321 --> 00:10:16.822
-then it can be navigation
+then it can be navigation,
 
 00:10:16.823 --> 00:10:19.324
 or even you are actually writing
 some button,
 
 00:10:19.325 --> 00:10:23.629
-then instead of div,
-you can actually use button.
+then instead of &lt;div&gt;,
+you can actually use &lt;button&gt;.
 
 00:10:24.631 --> 00:10:30.436
 In this way, you can actually
 differentiate right markup
 
 00:10:30.437 --> 00:10:34.506
-or semantic HTML instead of div.
+or semantic HTML instead of &lt;div&gt;.
 
 00:10:34.941 --> 00:10:40.079
 The next thing is choose
@@ -683,37 +679,37 @@ not for the same
 importantness or same priority.
 
 00:10:49.355 --> 00:10:54.093
-You should use H1
+You should use &lt;h1&gt;
 for the most important title,
 
 00:10:54.094 --> 00:10:58.764
-then H2, then H3,
-then H4, then H5, then H6.
+then &lt;h2&gt;, then &lt;h3&gt;,
+then &lt;h4&gt;, then &lt;h5&gt;, then &lt;h6&gt;.
 
 00:10:59.399 --> 00:11:02.652
 You need to choose
 your heading logically.
 
 00:11:05.972 --> 00:11:10.042
-Sorry, so avoid the divs.
+Sorry, so avoid the &lt;div&gt;s.
 
 00:11:11.578 --> 00:11:16.949
 Some developer use
-div most of the places.
+&lt;div&gt; most of the places.
 
 00:11:17.217 --> 00:11:19.718
-Avoid, use div most of the places.
+Avoid, use &lt;div&gt; most of the places.
 
 00:11:19.719 --> 00:11:23.002
 There are some most HTML
 element in there
 
 00:11:23.003 --> 00:11:27.326
-like aside, footer, main, article.
+like &lt;aside&gt;, &lt;footer&gt;, &lt;main&gt;, &lt;article&gt;.
 
 00:11:27.527 --> 00:11:31.397
 You can use those type
-of element instead of div.
+of element instead of &lt;div&gt;.
 
 00:11:31.898 --> 00:11:37.803
 This is the common,
@@ -724,17 +720,17 @@ the template part of the team.
 
 00:11:42.142 --> 00:11:46.111
 Here, you can use
-header instead of div.
+&lt;header&gt;instead of &lt;div&gt;.
 
 00:11:46.112 --> 00:11:47.930
 We can use navigation.
 
 00:11:49.549 --> 00:11:53.619
 If you are actually using navigation,
-then you can use nav,
+then you can use &lt;nav&gt;,
 
 00:11:53.620 --> 00:11:55.387
-then footer for the site-footer.
+then &lt;footer&gt;for the site-footer.
 
 00:11:55.388 --> 00:11:58.027
 These are the things
@@ -742,7 +738,7 @@ you can actually implement
 
 00:11:58.028 --> 00:12:02.628
 as a semantic HTML instead
-of div or some other things.
+of &lt;div&gt;or some other things.
 
 00:12:02.896 --> 00:12:05.364
 Put the right things
@@ -779,7 +775,7 @@ as a main content of the page.
 
 00:12:42.569 --> 00:12:48.106
 You need to set your ARIA
-level or ARIA role accordingly.
+label or ARIA role accordingly.
 
 00:12:49.576 --> 00:12:55.147
 Don't overuse it, but you need
@@ -796,7 +792,7 @@ how the ARIA can be described,
 this is the navigation.
 
 00:13:09.462 --> 00:13:13.599
-Instead of div, we can use nav,
+Instead of &lt;div&gt;, we can use &lt;nav&gt;,
 and this is the label.
 
 00:13:13.600 --> 00:13:17.469
@@ -808,7 +804,7 @@ and then we don't have any search
 element in HTML.
 
 00:13:24.477 --> 00:13:26.378
-We can use div and set
+We can use &lt;div&gt; and set
 
 00:13:26.379 --> 00:13:30.015
 the role and the label
@@ -843,7 +839,7 @@ this is some tab functionality.
 
 00:13:58.845 --> 00:14:04.850
 I can say here it is if I go
-into the English American,
+into the English, American,
 
 00:14:04.851 --> 00:14:08.720
 so the respective things
@@ -868,10 +864,10 @@ which is like this one.
 
 00:14:27.006 --> 00:14:33.011
 In this, in here,
-this nav will represent this one.
+this &lt;nav&gt; will represent this one.
 
 00:14:33.012 --> 00:14:38.950
-In nav, I can say that
+In &lt;nav&gt;, I can say that
 the aria-label I actually define,
 
 00:14:38.951 --> 00:14:41.182
@@ -883,7 +879,7 @@ then it will define
 
 00:14:44.757 --> 00:14:48.126
 like what is the main
-purpose of this nav.
+purpose of this &lt;nav&gt;.
 
 00:14:48.361 --> 00:14:50.262
 In this way, we can actually define
@@ -1048,11 +1044,11 @@ some button in your block,
 
 00:17:40.066 --> 00:17:43.635
 you can actually
-do so like this way on key down,
+do so like this way onKeyDown,
 
 00:17:43.636 --> 00:17:49.074
-when either it is enter,
-either it is a space, you can write
+when either it is Enter,
+either it is a Space, you can write
 
 00:17:49.075 --> 00:17:51.389
 your function like this way.
@@ -1065,7 +1061,7 @@ how these things can be done.
 Here I click in here.
 
 00:17:58.818 --> 00:18:00.853
-If I press the tab,
+If I press the Tab,
 
 00:18:01.888 --> 00:18:05.591
 it is actually navigate
@@ -1073,7 +1069,7 @@ through one by one.
 
 00:18:08.027 --> 00:18:12.198
 Then if I click on the this one,
-then if I hit tab,
+then if I hit Tab,
 
 00:18:12.431 --> 00:18:16.629
 and now I'm pressing next
@@ -1093,32 +1089,32 @@ When I choose any category
 through the next and previous,
 
 00:18:37.423 --> 00:18:41.693
-and hit enter,
+and hit Enter,
 then selected category will be shown.
 
 00:18:41.694 --> 00:18:43.962
-Crime, press enter, fiction,
+Crime, press Enter, Fiction,
 
 00:18:43.963 --> 00:18:48.433
-press enter, French, press enter,
-natural, press enter.
+press Enter, French, press Enter,
+Nature, press Enter.
 
 00:18:48.434 --> 00:18:52.804
-If I go to fiction
-again and press space,
+If I go to Fiction
+again and press Space,
 
 00:18:52.805 --> 00:18:55.073
 then it is also visible.
 
 00:18:55.074 --> 00:19:00.946
-Crime, press, crime, love,
-press space, classic, press space,
+Crime, press, Crime, Love,
+press Space, Classic, press Space,
 
 00:19:00.947 --> 00:19:02.930
 then it is also visible.
 
 00:19:03.015 --> 00:19:05.917
-Then if I press tab again,
+Then if I press Tab again,
 then it will go
 
 00:19:05.918 --> 00:19:06.985
@@ -1177,7 +1173,7 @@ functionality will be executed.
 Then there are some other things,
 
 00:20:03.109 --> 00:20:06.412
-which is press enter and press space.
+which is press Enter and press Space.
 
 00:20:08.114 --> 00:20:13.418
 This functionality is activate
@@ -1232,14 +1228,14 @@ are actually selected.
 See, the entire things are selected.
 
 00:21:00.399 --> 00:21:01.866
-If I press enter,
+If I press Enter,
 
 00:21:01.867 --> 00:21:05.870
 then it actually go
 into the respective post.
 
 00:21:05.871 --> 00:21:08.306
-See if I click enter, then it will go
+See if I click Enter, then it will go
 
 00:21:08.307 --> 00:21:12.036
 into the respective
@@ -1381,7 +1377,7 @@ Right now it is not implemented,
 but you can actually add
 
 00:23:44.763 --> 00:23:48.234
-this functionality
+this sort of functionality
 for the good practice.
 
 00:23:49.902 --> 00:23:52.051
@@ -1434,7 +1430,7 @@ is not provided, then we can add
 
 00:24:35.814 --> 00:24:40.285
 some fallback here,
-like No featured image found.
+like "No featured image found".
 
 00:24:40.753 --> 00:24:45.037
 In this way, we can actually
@@ -1473,7 +1469,7 @@ In this way,
 we can add some alternative text.
 
 00:25:21.427 --> 00:25:24.929
-Then we go into the color
+Then we go into the colour
 contrast ratio.
 
 00:25:25.197 --> 00:25:26.998
@@ -1481,7 +1477,7 @@ Ensure that the text and interactive
 
 00:25:26.999 --> 00:25:30.268
 elements have some sufficient
-color contrast ratio.
+colour contrast ratio.
 
 00:25:30.269 --> 00:25:36.808
 It needs to be WCAG 2.1 AA,
@@ -1504,21 +1500,21 @@ if we give our user or give the user
 
 00:26:00.050 --> 00:26:04.369
 of the block the ability to set
-the color contrast things,
+the colour contrast things,
 
 00:26:04.370 --> 00:26:07.271
 then we can do like this way,
 
 00:26:07.272 --> 00:26:11.175
-this is the color settings,
-user can change the text color,
+this is the colour settings,
+user can change the text colour,
 
 00:26:11.176 --> 00:26:13.978
-user can change the background color.
+user can change the background colour.
 
 00:26:13.979 --> 00:26:18.016
 If anything is having
-some color contrast ratio,
+some colour contrast issue,
 
 00:26:18.017 --> 00:26:20.744
 so these things might be helpful.
@@ -1527,21 +1523,21 @@ so these things might be helpful.
 Now, if I go into this block,
 
 00:26:29.741 --> 00:26:33.470
-so I can check the color
+so I can check the colour
 contrast ratio of this,
 
 00:26:34.140 --> 00:26:36.871
-I can say the label.
+I can say, the label.
 
 00:26:36.935 --> 00:26:41.639
 Here, I open a tool to check
-the color contrast ratio.
+the colour contrast ratio.
 
 00:26:42.574 --> 00:26:48.981
 Right now, I'm checking the tools,
 
 00:26:50.883 --> 00:26:54.585
-checking the color
+checking the colour
 contrast ratio of this text.
 
 00:26:54.887 --> 00:27:00.059
@@ -1549,14 +1545,14 @@ Right now, these things,
 which is here,
 
 00:27:00.359 --> 00:27:05.364
-the color of this section is here.
+the colour of this section is here.
 
 00:27:06.165 --> 00:27:09.767
-If I choose the text color,
-this is the text color,
+If I choose the text colour,
+this is the text colour,
 
 00:27:09.768 --> 00:27:12.070
-and the background is FFF.
+and the background is #FFF.
 
 00:27:12.071 --> 00:27:17.420
 See, this is small text,
@@ -1582,7 +1578,7 @@ then it will give
 you the good result.
 
 00:27:35.160 --> 00:27:38.597
-If I choose the color
+If I choose the colour
 contrast like this,
 
 00:27:38.697 --> 00:27:42.934
@@ -1591,21 +1587,21 @@ and it will be accessible
 
 00:27:42.935 --> 00:27:47.238
 for the people who is having
-some color contrast ratio.
+some colour contrast issue.
 
 00:27:47.506 --> 00:27:52.028
 In this way, we can actually
-set the color contrast ratio.
+set the colour contrast ratio.
 
 00:27:52.578 --> 00:27:54.645
 There are some other tools to check
 
 00:27:54.646 --> 00:27:58.058
-the color contrast ratio,
+the colour contrast ratio,
 which is this one.
 
 00:28:01.620 --> 00:28:06.539
-You can define your color here,
+You can define your colour here,
 and you can check each of them.
 
 00:28:07.059 --> 00:28:12.564
@@ -1614,25 +1610,25 @@ and this is the text.
 
 00:28:12.831 --> 00:28:17.268
 For this background,
-which text color will be good?
+which text colour will be good?
 
 00:28:18.137 --> 00:28:23.107
-We can check the score for this color
+We can check the score for this colour
 or for this background.
 
 00:28:23.108 --> 00:28:24.976
-Which color is good?
+Which colour is good?
 
 00:28:24.977 --> 00:28:30.148
-For this color,
-this color is good enough.
+For this colour,
+this colour is good enough.
 
 00:28:30.449 --> 00:28:32.984
 You can check these things,
 or you can put
 
 00:28:32.985 --> 00:28:38.489
-your site color code here,
+your site colour code here,
 both text and background,
 
 00:28:38.490 --> 00:28:41.927
@@ -1646,10 +1642,10 @@ which is handling
 the dynamic content.
 
 00:28:50.836 --> 00:28:54.872
-When you are having some pagination.
+When you are having some pagination,
 
 00:28:56.975 --> 00:28:59.677
-In that case,
+in that case,
 if you want your user to show
 
 00:28:59.678 --> 00:29:03.814
@@ -1695,8 +1691,8 @@ Or if you load more content
 without reloading the page
 
 00:29:39.384 --> 00:29:41.986
-by clicking the load
-more post button,
+by clicking the "load
+more post" button,
 
 00:29:41.987 --> 00:29:47.458
 then you need to add
@@ -1767,7 +1763,7 @@ but here I actually add
 something in here,
 
 00:31:02.868 --> 00:31:05.678
-like read more about these things.
+like "read more about these things".
 
 00:31:05.837 --> 00:31:12.810
 It is not about the title,
@@ -1781,16 +1777,16 @@ then they must actually
 read these things,
 
 00:31:18.250 --> 00:31:20.818
-like read more about
+like "read more about
 the ancient temple
 
 00:31:20.819 --> 00:31:24.072
-stood as a testament,
+stood as a testament",
 something like that.
 
 00:31:27.192 --> 00:31:31.195
 In this case,
-if you are not having these things,
+if you are not having these sort of things,
 
 00:31:31.196 --> 00:31:37.034
 like aria-label, then you should use
@@ -1810,13 +1806,13 @@ thing of this card block.
 
 00:31:54.186 --> 00:31:58.322
 If I click on this card
-or if I press enter,
+or if I press Enter,
 
 00:31:58.323 --> 00:32:02.942
 then what will be the next thing
 
 00:32:02.943 --> 00:32:07.932
-if I press enter
+if I press Enter
 or if I click in here?
 
 00:32:09.067 --> 00:32:11.135
@@ -1852,13 +1848,13 @@ I can ask anything
 in these Chrome DevTools, ask AI.
 
 00:32:54.846 --> 00:32:57.549
-If I run something like audit
+If I run something like "audit
 
 00:32:59.418 --> 00:33:03.922
-this markup for accessibility
+this markup for accessibility"
 
 00:33:04.990 --> 00:33:06.991
-and press enter, it will analyze
+and press Enter, it will analyse
 
 00:33:06.992 --> 00:33:11.695
 the things and tell
@@ -1879,14 +1875,14 @@ like what can be the next things
 you can ask,
 
 00:33:23.508 --> 00:33:26.911
-check color contrast
+check colour contrast
 of the text and background.
 
 00:33:26.912 --> 00:33:29.280
 If I click on here, send the things,
 
 00:33:29.281 --> 00:33:32.583
-check the color contrast
+check the colour contrast
 of the text and background,
 
 00:33:32.584 --> 00:33:34.804
@@ -1903,7 +1899,7 @@ we can use AI tools by default.
 
 00:33:45.230 --> 00:33:47.631
 Definitely, the ChatGPT,
-the Cloud is there,
+the Claude is there,
 
 00:33:47.632 --> 00:33:49.767
 but this is the Chrome DevTools.
@@ -1918,14 +1914,14 @@ this is something like good to know,
 
 00:34:07.652 --> 00:34:11.555
 if you are having some ambiguous
-test, like read more.
+test, like "read more".
 
 00:34:11.556 --> 00:34:12.958
 For example,
 
 00:34:14.125 --> 00:34:20.498
 for the side categories, if I add
-some read-more button in here,
+some "Read more" button in here,
 
 00:34:20.499 --> 00:34:24.001
 that counts as a actually
@@ -1936,7 +1932,7 @@ When user comes into that,
 then a screen reader text
 
 00:34:27.639 --> 00:34:30.201
-will read about like read more.
+will read about like "read more".
 
 00:34:30.408 --> 00:34:32.776
 The thing is that read
@@ -1946,24 +1942,24 @@ more about what?
 Read more about what?
 
 00:34:34.546 --> 00:34:37.281
-If I add read more in here, in here,
+If I add "read more" in here, in here,
 
 00:34:37.282 --> 00:34:41.585
 and here, so each time
 a screen reader comes into here
 
 00:34:41.586 --> 00:34:44.788
-and read more, read more, read more.
+and read "read more, read more, read more".
 
 00:34:44.956 --> 00:34:48.158
-The thing is that read
+The thing is that, read
 more about what?
 
 00:34:48.460 --> 00:34:50.528
 You need to add some more context
 
 00:34:50.529 --> 00:34:53.697
-in that read more,
+in that "read more",
 like read more about this,
 
 00:34:53.698 --> 00:34:56.400
@@ -1974,8 +1970,11 @@ read more about this.
 In this way, you can actually
 fix some ambiguous text.
 
-00:35:03.975 --> 00:35:05.264
+00:35:02.674 --> 00:35:03.999
 Empty button.
+
+00:35:04.000 --> 00:35:06.176
+Empty button is like...
 
 00:35:06.177 --> 00:35:10.548
 The most common example of empty
@@ -2020,24 +2019,24 @@ The next thing
 is incorrect heading order.
 
 00:35:47.986 --> 00:35:51.855
-If I set these things as an h3,
+If I set these things as an &lt;h3&gt;,
 
 00:35:51.856 --> 00:35:54.491
 for example, if I develop some block,
 
 00:35:54.492 --> 00:35:59.430
-which is having by default h3,
-but by default, that is h1.
+which is having by default h&lt;h3&gt;,
+but by default, that is &lt;h1&gt;.
 
 00:36:00.532 --> 00:36:04.735
 When the browser
-is passing that text,
+is parsing that text,
 
 00:36:04.736 --> 00:36:07.838
-then at first it will have h1
+then at first it will have &lt;h1&gt;
 
 00:36:07.839 --> 00:36:11.013
-and then h3,
+and then &lt;h3&gt;,
 in between there is no text.
 
 00:36:11.042 --> 00:36:14.145
@@ -2060,7 +2059,7 @@ that is open in a new tab,
 
 00:36:29.587 --> 00:36:33.871
 then you should add
-aria-label like opens in a new tab.
+aria-label like "opens in a new tab".
 
 00:36:34.899 --> 00:36:39.025
 This is something good to know
@@ -2077,7 +2076,7 @@ If I open the DevTool,
 I set testing environment here.
 
 00:36:55.553 --> 00:37:02.260
-If I open npm run jest as a coverage,
+If I open npm, "run jest" as a coverage,
 
 00:37:05.063 --> 00:37:08.273
 I write some text regarding some--
@@ -2142,7 +2141,7 @@ The next part is Playwright,
 which is the most important part.
 
 00:38:16.801 --> 00:38:19.349
-I write one playwright test
+I write one Playwright test
 
 00:38:19.350 --> 00:38:25.275
 regarding the feature post.
@@ -2154,7 +2153,7 @@ Here it is.
 Test, end-to-end, and featured post.
 
 00:38:38.256 --> 00:38:41.960
-I can say what it does,
+What it does, I can say,
 it will create a page,
 
 00:38:42.327 --> 00:38:45.963
@@ -2184,8 +2183,8 @@ Let's run the test.
 There it is.
 
 00:39:20.732 --> 00:39:26.136
-At first, I should say npx,
-then playwright, then test.
+At first, I should say "npx",
+then "playwright", then "test".
 
 00:39:26.137 --> 00:39:30.421
 Of course, the testing
@@ -2268,7 +2267,7 @@ to test your tab functionality
 or keyboard functionality, I can say.
 
 00:40:41.880 --> 00:40:44.816
-That is the playwright testing thing.
+That is the Playwright testing thing.
 
 00:40:45.049 --> 00:40:49.571
 Some other tools which is available,
@@ -2285,7 +2284,7 @@ I can choose desktop or mobile.
 
 00:40:57.829 --> 00:41:02.199
 I can choose accessibility,
-analyze the page load.
+analyse the page load.
 
 00:41:02.367 --> 00:41:05.535
 It will give
@@ -2327,12 +2326,8 @@ let me know.
 00:41:38.269 --> 00:41:39.269
 Thank you.
 
-00:41:39.319 --> 00:41:40.519
-Anam Hossain: Thank you.
-
 00:41:41.405 --> 00:41:44.295
-Annabelle Drumm:
-Thank you so much, Anam,
+<v Annabelle> Thank you so much, Anam,
 
 00:41:44.455 --> 00:41:46.548
 for that really great presentation.
@@ -2367,325 +2362,325 @@ installed on your WordPress site.
 Could you tell us a little bit
 about what you use it for?
 
-00:42:19.647 --> 00:42:20.747
-Anam: Can you hear me?
+00:42:19.000 --> 00:42:20.747
+<v Anam> Can you hear me?
 
-00:42:22.478 --> 00:42:23.482
-Annabelle: Yes.
+00:42:21.478 --> 00:42:23.482
+<v Annabelle> Yes.
 
-00:42:26.097 --> 00:42:27.927
-Anam: Thank you for asking this question.
+00:42:25.097 --> 00:42:27.927
+<v Anam> Thank you for asking this question.
 
-00:42:27.927 --> 00:42:31.488
+00:42:27.927 --> 00:42:30.488
 Actually, GraphQL
 is not for accessibility,
 
-00:42:31.628 --> 00:42:35.889
+00:42:30.628 --> 00:42:35.000
 but you can use it for creating your post.
 
-00:42:36.069 --> 00:42:42.829
+00:42:38.500 --> 00:42:41.999
 I can say it will open
 some post-related stuff.
 
-00:42:42.998 --> 00:42:49.189
-When you are creating your own block,
+00:42:42.000 --> 00:42:48.189
+So when you are creating your own block,
 you can fetch those posts
 
-00:42:49.239 --> 00:42:50.269
+00:42:48.239 --> 00:42:49.269
 using the GraphQL.
 
-00:42:50.509 --> 00:42:53.059
+00:42:49.509 --> 00:42:52.059
 I use GraphQL
 for headless WordPress mostly,
 
-00:42:53.348 --> 00:42:57.178
+00:42:52.348 --> 00:42:56.178
 but GraphQL is not a part of this part.
 
-00:42:57.568 --> 00:43:02.028
+00:42:56.568 --> 00:43:01.028
 I installed the WordPress default
 GraphQL plugin
 
-00:43:02.058 --> 00:43:07.069
+00:43:01.058 --> 00:43:06.069
 for my own learning purpose,
 but that is another thing.
 
-00:43:08.589 --> 00:43:09.589
-Annabelle: Great.
+00:43:07.589 --> 00:43:08.589
+<v Annabelle> Great.
 
-00:43:10.278 --> 00:43:11.838
+00:43:9.278 --> 00:43:10.838
 David has another question as well.
 
-00:43:11.838 --> 00:43:17.839
+00:43:10.838 --> 00:43:16.839
 What resources can you suggest to learn
 how to create your own Gutenberg blocks?
 
-00:43:20.298 --> 00:43:23.486
-Anam: By default, WordPress
+00:43:19.298 --> 00:43:22.486
+<v Anam> By default, WordPress
 provides a few of the things,
 
-00:43:23.487 --> 00:43:27.167
+00:43:22.487 --> 00:43:26.167
 like block-related resource.
 
-00:43:27.168 --> 00:43:30.801
-I can say the developer WordPress.org [?]
+00:43:26.168 --> 00:43:29.801
+I can say the developer WordPress.org [unintelligible]
 is a block editor.
 
-00:43:30.910 --> 00:43:35.527
+00:43:29.910 --> 00:43:34.527
 Resource is there, and there are
 some good GitHub example is there.
 
-00:43:35.787 --> 00:43:41.539
+00:43:34.787 --> 00:43:40.539
 You can check those GitHub repo
 for learning the Gutenberg-related stuff.
 
-00:43:41.772 --> 00:43:47.179
+00:43:40.772 --> 00:43:46.179
 WordPress have good documentation
 regarding the Gutenberg-related stuff.
 
-00:43:47.869 --> 00:43:49.789
+00:43:46.869 --> 00:43:48.789
 That is the best part I can say
 
-00:43:50.989 --> 00:43:54.889
+00:43:49.989 --> 00:43:53.889
 to getting started
 for the Gutenberg development.
 
-00:43:56.739 --> 00:43:59.590
-Annabelle: Can you give some details
+00:43:55.739 --> 00:43:58.590
+<v Annabelle> Can you give some details
 on that testing tool that you were using?
 
-00:43:59.590 --> 00:44:00.940
-[?] is asking.
+00:43:58.590 --> 00:44:59.940
+Anis is asking.
 
-00:44:02.310 --> 00:44:04.000
-Anam: Thanks for asking.
+00:44:01.310 --> 00:44:03.000
+<v Anam> Thanks for asking.
 
-00:44:04.260 --> 00:44:09.018
+00:44:03.260 --> 00:44:08.018
 At first, you need to set
 some testing environment,
 
-00:44:09.019 --> 00:44:10.019
+00:44:08.019 --> 00:44:09.019
 I can say.
 
-00:44:10.059 --> 00:44:13.171
+00:44:09.059 --> 00:44:12.171
 Regarding the visual-related stuff,
 WordPress suggests Playwright,
 
-00:44:13.171 --> 00:44:16.271
+00:44:12.171 --> 00:44:15.271
 and WordPress have good documentation
 regarding the Playwright.
 
-00:44:16.490 --> 00:44:21.318
+00:44:15.490 --> 00:44:20.318
 You can follow those steps
 in the WordPress documentation.
 
-00:44:21.319 --> 00:44:22.549
+00:44:20.319 --> 00:44:21.549
 You have those links.
 
-00:44:22.985 --> 00:44:23.985
+00:44:21.985 --> 00:44:22.985
 Set those up,
 
-00:44:24.138 --> 00:44:28.729
+00:44:23.138 --> 00:44:27.729
 but the things I write,
 which is tab-related functionality,
 
-00:44:28.969 --> 00:44:32.419
+00:44:27.969 --> 00:44:31.419
 so you can write it manually regarding
 your own,
 
-00:44:33.018 --> 00:44:34.600
+00:44:32.018 --> 00:44:33.600
 based on your own development.
 
-00:44:35.229 --> 00:44:38.246
+00:44:34.229 --> 00:44:37.246
 When the things are actually
 
-00:44:38.829 --> 00:44:42.969
+00:44:37.829 --> 00:44:41.969
 in the development process,
 then you can set either it is tab,
 
-00:44:43.079 --> 00:44:48.707
+00:44:42.079 --> 00:44:47.707
 so if you wanted to press the link
-or press the enter or space,
+or press the Enter or Space,
 
-00:44:48.708 --> 00:44:52.158
+00:44:47.708 --> 00:44:51.158
 then you can choose
 your functionality, like that way.
 
-00:44:52.579 --> 00:44:53.629
+00:44:51.579 --> 00:44:52.629
 But before that,
 
-00:44:53.689 --> 00:44:55.789
+00:44:52.689 --> 00:44:54.789
 you need to set
 the Playwright environment.
 
-00:44:57.843 --> 00:45:01.492
-Annabelle: There's quite a few people
+00:44:56.843 --> 00:45:00.492
+<v Annabelle> There's quite a few people
 actually asking about your tools,
 
-00:45:01.493 --> 00:45:03.193
+00:45:00.493 --> 00:45:02.193
 and they were in the chat as well,
 
-00:45:04.578 --> 00:45:08.149
+00:45:03.578 --> 00:45:07.149
 including the AI
 from your Chrome DevTools.
 
-00:45:08.508 --> 00:45:12.079
+00:45:07.508 --> 00:45:11.079
 Have you got any examples of
 when you've used that AI?
 
-00:45:12.279 --> 00:45:14.129
+00:45:11.279 --> 00:45:13.129
 Have you found it useful in that way?
 
-00:45:16.119 --> 00:45:20.449
-Anam: Before using AI,
+00:45:15.119 --> 00:45:19.449
+<v Anam> Before using AI,
 I always suggest you know it,
 
-00:45:20.868 --> 00:45:25.248
+00:45:19.868 --> 00:45:24.248
 because if you are asking AI
-regarding some area roles,
+regarding some ARIA roles,
 
-00:45:25.638 --> 00:45:33.474
-just actually learn about the area roles,
+00:45:24.638 --> 00:45:32.474
+just actually learn about the ARIA roles,
 because not every time AI
 
-00:45:33.852 --> 00:45:39.108
+00:45:32.852 --> 00:45:38.108
 gives you the best result for you,
 because the purpose you needed,
 
-00:45:39.258 --> 00:45:42.737
+00:45:38.258 --> 00:45:41.737
 but AI sometimes gives
 you the different results.
 
-00:45:42.738 --> 00:45:47.418
+00:45:41.738 --> 00:45:46.418
 Before you take example
 or take answer from AI,
 
-00:45:48.228 --> 00:45:51.678
+00:45:47.228 --> 00:45:50.678
 at first learn it yourself,
 because if you are not having
 
-00:45:51.679 --> 00:45:57.588
+00:45:50.679 --> 00:45:56.588
 any experience, then you might not get
 the right answer from the AI also.
 
-00:45:59.259 --> 00:46:01.369
+00:45:58.259 --> 00:46:00.369
 If I get confused with AI,
 
-00:46:01.428 --> 00:46:04.449
+00:46:00.428 --> 00:46:03.449
 I also use some of the,
 
-00:46:04.529 --> 00:46:08.118
+00:46:03.529 --> 00:46:07.118
 I can say, the MDN resource,
 like Mozilla resource.
 
-00:46:08.949 --> 00:46:11.749
+00:46:07.949 --> 00:46:10.749
 I use those things
 as my personal learning,
 
-00:46:12.019 --> 00:46:16.607
+00:46:11.019 --> 00:46:15.607
 but when I got some of those things,
 I got to know from my experience,
 
-00:46:16.608 --> 00:46:22.603
-then I use the ChatGPT Cloud
+00:46:15.608 --> 00:46:21.603
+then I use the ChatGPT or Claude
 for the more detailed use case,
 
-00:46:22.893 --> 00:46:27.154
+00:46:21.893 --> 00:46:26.154
 but if I'm on development process,
 then Google Chrome DevTools,
 
-00:46:27.205 --> 00:46:31.419
+00:46:26.205 --> 00:46:30.419
 like Google AI comes into play
 for most of the cases.
 
-00:46:32.678 --> 00:46:36.367
-Annabelle: Is it possible for you
+00:46:31.678 --> 00:46:35.367
+<v Annabelle> Is it possible for you
 to perhaps make a list
 
-00:46:36.368 --> 00:46:37.429
+00:46:35.368 --> 00:46:36.429
 of some of the tools
 
-00:46:37.429 --> 00:46:39.888
+00:46:36.429 --> 00:46:38.888
 that you are using
 in your demonstration today,
 
-00:46:40.309 --> 00:46:42.348
+00:46:39.309 --> 00:46:41.348
 and then perhaps
 we can have them available
 
-00:46:42.348 --> 00:46:44.929
+00:46:41.348 --> 00:46:43.929
 for people afterwards,
 once the video is released?
 
-00:46:45.858 --> 00:46:47.299
-Anam: Sure, definitely.
+00:46:44.858 --> 00:46:46.299
+<v Anam> Sure, definitely.
 
-00:46:47.499 --> 00:46:48.849
-Annabelle: That'd be great.
+00:46:46.499 --> 00:46:47.849
+<v Annabelle> That'd be great.
 
-00:46:49.329 --> 00:46:50.944
+00:46:48.329 --> 00:46:49.944
 Thank you so much, everyone,
 
-00:46:50.945 --> 00:46:54.215
+00:46:49.945 --> 00:46:53.215
 for attending the session
 with Anam Hossain.
 
-00:46:54.588 --> 00:46:58.308
+00:46:53.588 --> 00:46:57.308
 You can continue your conversation
 in chat for a wee while,
 
-00:46:58.449 --> 00:47:00.138
+00:46:57.449 --> 00:47:59.138
 or on social media,
 
-00:47:00.369 --> 00:47:07.226
-using the hashtag WPA11YDAY.
+00:47:59.369 --> 00:47:06.226
+using the hashtag #WPA11YDAY.
 
-00:47:07.458 --> 00:47:14.568
+00:47:06.458 --> 00:47:13.568
 Another hashtag
-is WPAD2025We'd also appreciate it
+is #WPAD2025, and we'd also appreciate it
 
-00:47:14.598 --> 00:47:24.851
+00:47:13.598 --> 00:47:23.851
 if you could go to the URL
 2025.wpaccessibility.day/feedback,
 
-00:47:25.279 --> 00:47:29.059
+00:47:24.279 --> 00:47:28.059
 and then you can provide
 anonymous feedback for our speakers
 
-00:47:29.149 --> 00:47:30.438
+00:47:28.149 --> 00:47:29.438
 on their presentation.
 
-00:47:30.918 --> 00:47:34.188
+00:47:29.918 --> 00:47:33.188
 You can enter to win
-a t-shirt while you're there.
+a T-shirt while you're there.
 
-00:47:35.089 --> 00:47:40.008
+00:47:34.089 --> 00:47:39.008
 Stay tuned for the next session,
 which is Real Inclusion: How to Run
 
-00:47:40.009 --> 00:47:44.658
+00:47:39.009 --> 00:47:43.658
 Insightful and Respectful User Testing
 with Disabled People.
 
-00:47:44.989 --> 00:47:50.089
+00:47:43.989 --> 00:47:49.089
 That's coming up with Lucy Collins
 at 7:00 AM UTC time.
 
-00:47:50.658 --> 00:47:51.708
+00:47:49.658 --> 00:47:50.708
 While you're waiting,
 
-00:47:51.829 --> 00:47:57.648
+00:47:50.829 --> 00:47:56.648
 don't forget to visit our sponsors' pages
 to grab virtual swag and enter
 
-00:47:57.660 --> 00:47:59.989
+00:47:56.660 --> 00:47:58.989
 for a chance to win great prizes.
 
-00:48:00.258 --> 00:48:04.249
+00:48:59.258 --> 00:48:03.249
 Thank you again, Anam,
 and I'll see you guys right here
 
-00:48:04.298 --> 00:48:05.298
+00:48:03.298 --> 00:48:04.298
 after the break.
 
-00:48:06.599 --> 00:48:08.268
-Anam: Thank you so much.
+00:48:05.599 --> 00:48:07.268
+<v Anam> Thank you so much.


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
# Proofreading edits to VTT for Making Gutenberg Blocks Accessible

## Spelling language
- Captions use British English spellings as MC is Australian and speaker is from Bangladesh
  - specialises, optimisation, analyse
  - colour

## Edits

Sponsors' roll
- punctuation: use comma separator in list of sponsors at each sponsorship level, including at end of a caption if the list continues on to the next caption

1 change "speaker" to "announcer" to match other vtts

3-4 comma after Gravity Forms; lower case "f" in "flexible"

12 "Ally Web Accessibility", not "Ally,web accessibility"

15 "GreenGeeks Web Hosting", not "GreenGeeks, web hosting"

18-19 Combine captions. Change end time of 18 to 00:00:57.222 (original end time of 19). Delete 19.

41 colon after "Accessible" (to match punctuation used on talk's page at wpaccessibility.day)

44 comma after "agency"

49 "accessibility-first design"

129-137: use semicolons to separate list of topics. Use spaced en-dashes to offset "how ARIA roles can be implemented..."

139 extremely difficult to know if speaker is saying "ratio" or "issue". Going with "issue" as makes more sense.

151 remove "issue" (alt text describes the issue, not the image issue)

98-102, 177-209, 564-9: use character references &lt; and &gt; to create html elements for div, header, nav, button, aside, footer, article, h1, h2, etc.

219 "ARIA label", not "ARIA level"

237 comma between "English" and "American"

294 "onKeyDown", instead of "on key down" (match code in slides)

295 capitalise "Enter" and "Space"

308-12: capitalise category names (e.g. "Fiction"), "Enter" and "Space"

309 "Nature", not "Natural"

386 insert "sort of": "this sort of functionality"

400 "No featured image found" (with quotation marks)

434 "\#FFF" with \# symbol

444 "issue", not "ratio" (see 139 above)

459-60: punctuation. Comma at end of 459, lower case letter at start of 460

472 "load more post" in quotes

492 "read more about these things" in quotes

496-7 quotes around "read more about..." phrase

498 "these sort of things" (insert "sort of")

515-6 "audit this markup for accessibility" with quotes

529 Claude, not Cloud

533, 535, 538, 541, 546 "read more" with quotes (535 with capital R as name of button)

550 change start time from 00:35:03.975 to 00:35:02.674 (caption lagging speech); change end time from 00:35:05.264 to 00:35:03.999: "Empty button."

Add new caption after 550, start time 00:35:04.000, end time 00:35:06.176: "Empty button is like..."

567 (was 565) "parsing ", not "passing"

575 (was 574) "opens in a new tab" with quotes

580 (was 579) "run jest" with quotes

delete 652 (was 651) "Anam Hossain: Thank you"

662 change start time from 00:42:19.647 to 00:42:19.000 (caption lagging)

663 change start time from 00:42:22.478 to 00:42:21.478 (caption lagging)

664 change start time from 00:42:26.097 to 00:42:25.097 (caption lagging)

665 change end time from 00:42:31.488 to 00:42:30.488 (following caption lagging by c. 1s)

666 change start time from 00:42:31.628 to 00:42:30.628, change end time from 00:42:35.889 to 00:42:35.000

667 change start time from 00:42:36.069 to 00:42:38.500 (caption ahead); change end time from 00:42:42.829 to 00:42:41.999

668 change start time from 00:42:42.998 to 00:42:42.000; insert "So" at start; change end time from 00:42:49.189 to 00:42:48.189 (next caption lagging)

669 change start time from 00:42:49.239 to 00:42:48.239 (caption lagging); change end time from 00:42:50.269 to 00:42:49.269

670 change start time from 00:42:50.509 to 00:42:49.509 (caption lagging); bring end time forward by 1 sec

671-750 (end of talk) bring start and end times forward by 1 sec (captions lagging speech)

710-711 "ARIA", not "area"

722 "ChatGPT or Claude", not "ChatGPT Cloud"

736-7 add "#" symbol to hashtags

General:
- replaces speakers' names with voicemarks
- use first name only for speakers' names
- adds speech marks to audience questions where question was read out verbatim
- replace "&" with "\&amp;" in Q&A
- capitalise keyboard key names: Enter, Space, Tab
- Playwright with capital P unless written as a command-line command

## How Has This Been Tested?
To be tested after updated vtt has been deployed

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Spelling, punctuation, caption timings, captions merged, captions added

## Checklist:
- [ ] My code is tested.
- [ ] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [ ] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
