### PR TITLE
Fixes to vtt for Making Gutenberg Blocks Accessible

### DIFF
--- a/src/assets/captions/2025/making-gutenberg-blocks-accessible-practical-techniques-with-ai-and-devtools-en.vtt
+++ b/src/assets/captions/2025/making-gutenberg-blocks-accessible-practical-techniques-with-ai-and-devtools-en.vtt
@@ -698,7 +698,7 @@ Some developer use
 div most of the places.
 
 00:11:17.217 --> 00:11:19.718
-Avoid, use div most of the places.
+Avoid use div most of the places.
 
 00:11:19.719 --> 00:11:23.002
 There are some most HTML
@@ -720,7 +720,7 @@ the template part of the team.
 
 00:11:42.142 --> 00:11:46.111
 Here, you can use
-headerinstead of div.
+header instead of div.
 
 00:11:46.112 --> 00:11:47.930
 We can use navigation.
@@ -730,7 +730,7 @@ If you are actually using navigation,
 then you can use nav,
 
 00:11:53.620 --> 00:11:55.387
-then footerfor the site-footer.
+then footer for the site-footer.
 
 00:11:55.388 --> 00:11:58.027
 These are the things
@@ -738,7 +738,7 @@ you can actually implement
 
 00:11:58.028 --> 00:12:02.628
 as a semantic HTML instead
-of divor some other things.
+of div or some other things.
 
 00:12:02.896 --> 00:12:05.364
 Put the right things
@@ -2076,7 +2076,7 @@ If I open the DevTool,
 I set testing environment here.
 
 00:36:55.553 --> 00:37:02.260
-If I open "npm run jest" as a coverage,
+If I open "npm run jest" as a "coverage",
 
 00:37:05.063 --> 00:37:08.273
 I write some text regarding some--


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
Add voicemark to 00:03:01.388 --> 00:03:03.619 "<v ANAM HOSSAIN> Hi, I'm Anam."

Stripping out "\&lt;" and "\&gt;" character references (parser doesn't support them)

Adding "issue" back in below. Doesn't make sense, but it's what the speaker said:  
00:08:13.366 --> 00:08:17.569
because it actually
describe the image issue

Fixing timing in the following (original start time was 00:43:9.278, i.e. missing the zero before the nine. This caused the caption to keep popping up in different places throughout the presentation)  
00:43:09.278 --> 00:43:10.838
David has another question as well.

Add "something" to caption:  
00:35:04.000 --> 00:35:06.176
Empty button is something like...

"npm run jest" as a single phrase
00:36:55.553 --> 00:37:02.260
If I open "npm run jest" as a "coverage",

Remove comma after "avoid" in:  
00:11:17.217 --> 00:11:19.718
Avoid use div most of the places.

## How Has This Been Tested?
To be tested when updated vtt deployed

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Misc fixes

## Checklist:
- [ ] My code is tested.
- [ ] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [ ] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
