### PR TITLE
Fix minor caption errors in build-for-everyone-or-build-for-no-one-en.vtt

### DIFF
--- a/src/assets/captions/2025/build-for-everyone-or-build-for-no-one-en.vtt
+++ b/src/assets/captions/2025/build-for-everyone-or-build-for-no-one-en.vtt
@@ -1767,7 +1767,7 @@ to most web browsers.
 I'm using Chrome here.
 
 00:25:08.378 --> 00:25:11.749
-I searched for HTML5 outliner.
+I searched for HTML5 Outliner.
 
 00:25:12.816 --> 00:25:15.184
 You can see it appears
@@ -3125,7 +3125,7 @@ your network and your connections,
 needs some work done?"
 
 00:44:06.360 --> 00:44:08.922
-If you have development shops--
+If you have development chops--
 
 00:44:09.320 --> 00:44:11.319
 because the web


### PR DESCRIPTION
Corrected “shops” → “chops” and capitalized “Outliner” in HTML5 Outliner plugin.
